### PR TITLE
Convert items and entries to JSON and upload to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,23 @@ Home of register derivations
 # Requirements
 
 - Java 1.8+
+
+# Description
+
+Currently a Java command line application which reads an RSF file and stores a JSON representation of the Registers
+ described by the RSF in S3.
+
+# Usage 
+
+The applcation requires 3 arguments:
+
+- path to RSF file
+- s3 bucket
+- s3 key
+
+For example:
+
+    gradle shadowJar
+    cd build
+    java -jar openregister-derivation-all.jar /tmp/countries.rsf openregister.derivation derivation.json
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,26 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+    }
+}
+
+apply plugin: 'com.github.johnrengelman.shadow'
+
 apply plugin: 'java'
 apply from: 'external-dependencies.gradle'
 group 'openregister'
 
 repositories {
     mavenCentral()
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'uk.gov.register.derivation.Main'
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    compile googleGuice, commonsCodec, jackson
+    compile googleGuice, commonsCodec, jackson, awsS3
 
-    testCompile junit, mockito
+    testCompile junit, mockito, jsonAssert
 }
 
 task(run, type: JavaExec, dependsOn: ['classes']) {

--- a/external-dependencies.gradle
+++ b/external-dependencies.gradle
@@ -2,9 +2,11 @@ ext {
     googleGuice = 'com.google.inject:guice:4.1.0'
     jackson =  'com.fasterxml.jackson.core:jackson-databind:2.8.6'
     commonsCodec = 'commons-codec:commons-codec:1.10'
+    awsS3 = ['com.amazonaws:aws-java-sdk-s3:1.11.77', "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.8.6"]
 
 
     // test dependencies
     junit = ['junit:junit:4.12','org.hamcrest:hamcrest-library:1.3']
     mockito = 'org.mockito:mockito-core:1.9.5'
+    jsonAssert ='org.skyscreamer:jsonassert:1.4.0'
 }

--- a/src/main/java/uk/gov/register/derivation/Entry.java
+++ b/src/main/java/uk/gov/register/derivation/Entry.java
@@ -1,6 +1,12 @@
 package uk.gov.register.derivation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
 
 public class Entry {
 
@@ -18,8 +24,14 @@ public class Entry {
         this.sequenceNumber = sequenceNumber;
     }
 
+    @JsonIgnore
     public Instant getTimestamp() {
         return timestamp;
+    }
+
+    @JsonProperty("timestamp")
+    public String getTimestampAsString() {
+        return ISO_INSTANT.format(timestamp.truncatedTo(ChronoUnit.SECONDS));
     }
 
     public String getItemHash() {

--- a/src/main/java/uk/gov/register/derivation/JsonSerializer.java
+++ b/src/main/java/uk/gov/register/derivation/JsonSerializer.java
@@ -1,0 +1,12 @@
+package uk.gov.register.derivation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class JsonSerializer {
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String serialize(Object data) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(data);
+    }
+}

--- a/src/main/java/uk/gov/register/derivation/Main.java
+++ b/src/main/java/uk/gov/register/derivation/Main.java
@@ -1,21 +1,24 @@
 package uk.gov.register.derivation;
 
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public class Main {
     public static void main(String[] args) throws IOException {
+        Injector injector = Guice.createInjector(new Registrar());
+
         InputStream rsfStream = Files.newInputStream(Paths.get( args[0]));
-        RsfParser parser = new RsfParser();
+        RsfParser parser = injector.getInstance(RsfParser.class);
         Set<PartialEntity> entities = parser.parse(rsfStream);
-        Map<String, PartialEntity> partialEntityMap = entities.stream().collect(Collectors.toMap(PartialEntity::getKey, Function.identity()));
-        PartialEntity czechia = partialEntityMap.get("CZ");
-        System.out.println(czechia);
+
+        String jsonResult = JsonSerializer.serialize(entities);
+        Uploader uploader = injector.getInstance(Uploader.class);
+        uploader.upload("openregister.derivation", "derivation.json", jsonResult);
     }
 }

--- a/src/main/java/uk/gov/register/derivation/Main.java
+++ b/src/main/java/uk/gov/register/derivation/Main.java
@@ -11,14 +11,18 @@ import java.util.Set;
 
 public class Main {
     public static void main(String[] args) throws IOException {
-        Injector injector = Guice.createInjector(new Registrar());
+        if (args.length == 3) {
+            Injector injector = Guice.createInjector(new Registrar());
 
-        InputStream rsfStream = Files.newInputStream(Paths.get( args[0]));
-        RsfParser parser = injector.getInstance(RsfParser.class);
-        Set<PartialEntity> entities = parser.parse(rsfStream);
+            InputStream rsfStream = Files.newInputStream(Paths.get(args[0]));
+            RsfParser parser = injector.getInstance(RsfParser.class);
+            Set<PartialEntity> entities = parser.parse(rsfStream);
 
-        String jsonResult = JsonSerializer.serialize(entities);
-        Uploader uploader = injector.getInstance(Uploader.class);
-        uploader.upload("openregister.derivation", "derivation.json", jsonResult);
+            String jsonResult = JsonSerializer.serialize(entities);
+            Uploader uploader = injector.getInstance(Uploader.class);
+            uploader.upload(args[1], args[2], jsonResult);
+        } else {
+            System.err.println("Usage: args required - [rsf file path] [s3 bucket] [s3 key]");
+        }
     }
 }

--- a/src/main/java/uk/gov/register/derivation/Registrar.java
+++ b/src/main/java/uk/gov/register/derivation/Registrar.java
@@ -1,10 +1,12 @@
 package uk.gov.register.derivation;
 
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.google.inject.AbstractModule;
 
 public class Registrar extends AbstractModule {
     @Override
     protected void configure() {
-
+        bind(AmazonS3.class).to(AmazonS3Client.class);
     }
 }

--- a/src/main/java/uk/gov/register/derivation/Uploader.java
+++ b/src/main/java/uk/gov/register/derivation/Uploader.java
@@ -1,0 +1,23 @@
+package uk.gov.register.derivation;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.google.inject.Inject;
+
+public class Uploader {
+    private final AmazonS3 client;
+
+    @Inject
+    public Uploader(AmazonS3 client) {
+        this.client = client;
+    }
+
+    public void upload(String bucketName, String key, String value) {
+        try {
+            client.putObject(bucketName, key, value);
+        }
+        catch (SdkClientException ex) {
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/test/java/uk/gov/register/derivation/RsfSerializerTest.java
+++ b/src/test/java/uk/gov/register/derivation/RsfSerializerTest.java
@@ -1,0 +1,59 @@
+package uk.gov.register.derivation;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+
+public class RsfSerializerTest {
+    @Test
+    public void shouldSerializePartialEntitiesAsJson() throws IOException, JSONException {
+        PartialEntity entity = new PartialEntity("CZ");
+        Entry entry1 = new Entry(1, Instant.parse("2016-11-11T16:25:07Z"), "sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed");
+        Entry entry2 = new Entry(2, Instant.parse("2016-11-11T16:25:07Z"), "sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720");
+        entry1.setItem(new Item("{\"citizen-names\":\"Czech\",\"country\":\"CZ\",\"name\":\"Czech Republic\",\"official-name\":\"The Czech Republic\",\"start-date\":\"1993-01-01\"}"));
+        entry2.setItem(new Item("{\"citizen-names\":\"Czech\",\"country\":\"CZ\",\"name\":\"Czechia\",\"official-name\":\"The Czech Republic\",\"start-date\":\"1993-01-01\"}"));
+        entity.getEntries().addAll(Arrays.asList(entry1, entry2));
+
+        String result = JsonSerializer.serialize(entity);
+
+        String expectedJson = "{\n" +
+                "  \"key\": \"CZ\",\n" +
+                "  \"entries\": [\n" +
+                "    {\n" +
+                "      \"itemHash\": \"sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed\",\n" +
+                "      \"sequenceNumber\": 1,\n" +
+                "      \"item\": {\n" +
+                "        \"fields\": {\n" +
+                "          \"country\": \"CZ\",\n" +
+                "          \"official-name\": \"The Czech Republic\",\n" +
+                "          \"name\": \"Czech Republic\",\n" +
+                "          \"start-date\": \"1993-01-01\",\n" +
+                "          \"citizen-names\": \"Czech\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"timestamp\": \"2016-11-11T16:25:07Z\"\n" +
+                "    },\n" +
+                "    {\n" +
+                "      \"itemHash\": \"sha-256:c69c04fff98c59aabd739d43018e87a25fd51a00c37d100721cc68fa9003a720\",\n" +
+                "      \"sequenceNumber\": 2,\n" +
+                "      \"item\": {\n" +
+                "        \"fields\": {\n" +
+                "          \"country\": \"CZ\",\n" +
+                "          \"official-name\": \"The Czech Republic\",\n" +
+                "          \"name\": \"Czechia\",\n" +
+                "          \"start-date\": \"1993-01-01\",\n" +
+                "          \"citizen-names\": \"Czech\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"timestamp\": \"2016-11-11T16:25:07Z\"\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}";
+
+        JSONAssert.assertEquals(expectedJson, result, false);
+    }
+}

--- a/src/test/java/uk/gov/register/derivation/UploaderTest.java
+++ b/src/test/java/uk/gov/register/derivation/UploaderTest.java
@@ -1,0 +1,41 @@
+package uk.gov.register.derivation;
+
+import com.amazonaws.services.s3.AmazonS3;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class UploaderTest {
+    @Test
+    public void shouldUploadJsonFileToS3() {
+        String bucketName = "openregister.derivation";
+        String key = "derivation.json";
+        String content = "{\n" +
+                "  \"key\": \"CZ\",\n" +
+                "  \"entries\": [\n" +
+                "    {\n" +
+                "      \"itemHash\": \"sha-256:c45bd0b4785680534e07c627a5eea0d2f065f0a4184a02ba2c1e643672c3f2ed\",\n" +
+                "      \"sequenceNumber\": 1,\n" +
+                "      \"item\": {\n" +
+                "        \"fields\": {\n" +
+                "          \"country\": \"CZ\",\n" +
+                "          \"official-name\": \"The Czech Republic\",\n" +
+                "          \"name\": \"Czech Republic\",\n" +
+                "          \"start-date\": \"1993-01-01\",\n" +
+                "          \"citizen-names\": \"Czech\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"timestamp\": \"2016-11-11T16:25:07Z\"\n" +
+                "    }" +
+                "  ]\n" +
+                "}";
+
+        AmazonS3 client = mock(AmazonS3.class);
+
+        Uploader uploader = new Uploader(client);
+        uploader.upload(bucketName, key, content);
+
+        verify(client).putObject(bucketName, key, content);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to take a `PartialEntity` and convert it into JSON, with each `PartialEntity` representing a 'fat entry' (that is, all of the entries and corresponding items are contained within each `PartialEntity`).

We then upload this output to S3.